### PR TITLE
fix: change wrong scan adresses for fantom chain

### DIFF
--- a/crypto/assets/coinBlocksoftDict.json
+++ b/crypto/assets/coinBlocksoftDict.json
@@ -374,7 +374,7 @@
 		"tokenAddress": "0x6a07A792ab2965C72a5B8088d3a069A7aC3a993B",
 		"decimals": 18,
 		"tokenBlockchain": "FTM",
-		"currencyExplorerLink": "https://polygonscan.com/token/0x6a07A792ab2965C72a5B8088d3a069A7aC3a993B?a="
+		"currencyExplorerLink": "https://ftmscan.com/token/0x6a07A792ab2965C72a5B8088d3a069A7aC3a993B?a="
 	},
 	"ASH": {
 		"currencyType": "coin",
@@ -708,7 +708,7 @@
 		"tokenAddress": "0x321162Cd933E2Be498Cd2267a90534A804051b11",
 		"decimals": 8,
 		"tokenBlockchain": "FTM",
-		"currencyExplorerLink": "https://polygonscan.com/token/0x321162Cd933E2Be498Cd2267a90534A804051b11?a="
+		"currencyExplorerLink": "https://ftmscan.com/token/0x321162Cd933E2Be498Cd2267a90534A804051b11?a="
 	},
 	"FTM_BOO": {
 		"currencyType": "token",
@@ -721,7 +721,7 @@
 		"tokenAddress": "0x841fad6eae12c286d1fd18d1d525dffa75c7effe",
 		"decimals": 18,
 		"tokenBlockchain": "FTM",
-		"currencyExplorerLink": "https://polygonscan.com/token/0x841fad6eae12c286d1fd18d1d525dffa75c7effe?a="
+		"currencyExplorerLink": "https://ftmscan.com/token/0x841fad6eae12c286d1fd18d1d525dffa75c7effe?a="
 	},
 	"BNB_SMART_ADA": {
 		"currencyType": "token",
@@ -772,7 +772,7 @@
 		"tokenAddress": "0xb3654dc3d10ea7645f8319668e8f54d2574fbdc8",
 		"decimals": 18,
 		"tokenBlockchain": "FTM",
-		"currencyExplorerLink": "https://polygonscan.com/token/0xb3654dc3d10ea7645f8319668e8f54d2574fbdc8?a="
+		"currencyExplorerLink": "https://ftmscan.com/token/0xb3654dc3d10ea7645f8319668e8f54d2574fbdc8?a="
 	},
 	"ETH_NOW": {
 		"currencyType": "token",
@@ -1938,8 +1938,7 @@
 		"decimals": 6,
 		"tokenBlockchain": "FTM",
 		"tokenAddress": "0x04068da6c83afcfa0e13ba15a6696662335d5b75",
-		"currencyExplorerLink": "https://polygonscan.com/token/0x04068da6c83afcfa0e13ba15a6696662335d5b75?a=",
-		"currencyExplorerTxLink": "https://polygonscan.com/tx/"
+		"currencyExplorerLink": "https://ftmscan.com/token/0x04068da6c83afcfa0e13ba15a6696662335d5b75?a=",
 	},
 	"SOL_USDC": {
 		"currencyType": "token",


### PR DESCRIPTION
For some reason all of Fantom based token had polygon scan link. Which is confusing for a user.